### PR TITLE
Separate generated function builder.

### DIFF
--- a/src/StagedFilters.jl
+++ b/src/StagedFilters.jl
@@ -19,7 +19,10 @@ apply `filter` to `data` writing result to `smoothed`.
 Note that feeding `Int`s and not floats as data will result in a performance slowdown.
 """
 @generated function smooth!(::Type{SavitzkyGolayFilter{M,N}}, data :: AbstractArray{T}, smoothed :: AbstractArray{S}) where {M,N,T,S}
-
+  smooth_builder(T, M, N, false)
+end
+# separated for easier viewing of generated code
+function smooth_builder(::Type{T}, M::Int, N::Int, strip::Bool=true) where {T}
   J = T[(i - M - 1 )^(j - 1) for i = 1:2M + 1, j = 1:N + 1]
   e₁ = [one(T); zeros(T,N)]
   C = J' \ e₁
@@ -54,7 +57,7 @@ Note that feeding `Int`s and not floats as data will result in a performance slo
           return smoothed
   end
 
-  return last_expr = Base.remove_linenums!(last_expr)
+  return last_expr = strip ? Base.remove_linenums!(last_expr) : last_expr
 end;
 
 export SavitzkyGolayFilter, smooth!


### PR DESCRIPTION
Two changes:
1. Make it easier to look at the generated code:
```julia
julia> StagedFilters.smooth_builder(Float32,2,2)
quote
    n = length(data)
    n == length(smoothed) || throw(DimensionMismatch())
    #= /home/chriselrod/.julia/dev/StagedFilters/src/StagedFilters.jl:56 =# @inbounds for i = 1:2
            x = muladd(-0.08571424f0, data[wrapL(i - 2, n)], 0.0f0)
            x = muladd(0.34285715f0, data[wrapL(i - 1, n)], x)
            x = muladd(0.48571444f0, data[i], x)
            x = muladd(0.3428572f0, data[i + 1], x)
            x = muladd(-0.08571431f0, data[i + 2], x)
            smoothed[i] = x
        end
    #= /home/chriselrod/.julia/dev/StagedFilters/src/StagedFilters.jl:56 =# @avxt for i = 3:n - 2
            x = muladd(-0.08571424f0, data[i - 2], 0.0f0)
            x = muladd(0.34285715f0, data[i - 1], x)
            x = muladd(0.48571444f0, data[i], x)
            x = muladd(0.3428572f0, data[i + 1], x)
            x = muladd(-0.08571431f0, data[i + 2], x)
            smoothed[i] = x
        end
    #= /home/chriselrod/.julia/dev/StagedFilters/src/StagedFilters.jl:56 =# @inbounds for i = n - 1:n
            x = muladd(-0.08571424f0, data[i - 2], 0.0f0)
            x = muladd(0.34285715f0, data[i - 1], x)
            x = muladd(0.48571444f0, data[i], x)
            x = muladd(0.3428572f0, data[wrapR(i + 1, n)], x)
            x = muladd(-0.08571431f0, data[wrapR(i + 2, n)], x)
            smoothed[i] = x
        end
    return smoothed
end
```
2. Don't strip line number nodes by default, which should improve this package's test code coverage.