### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package implements a staged-programming approach for a highly specialized version of a Savitzky-Golay filter. It is a **generalized, performant algorithm** of [rolling/moving functions](https://en.wikipedia.org/wiki/Moving_average), such as a `rolling/moving average`.
 
-If you would like to read a full blog post on the implementation on it, [you can find some here](https://miguelraz.github.io/blog/).
+If you would like to read a full blog post on the implementation on it, [you can find some here](https://miguelraz.github.io/blog/smoothingjiahao/).
 For a video explanation by Stefan Karpinski, check out the [following video](https://www.youtube.com/watch?v=DRKKAFYM9yo&feature=youtu.be&t=2047)
 
 ### Acknowledgments

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # StagedFilters.jl - Lovingly handcrafted metaprogrammed code for all your DSP needs.
 
-This package implements a staged-programming approach for a highly specialized version of a Savitzky-Golay filter. It is a **generalized, performant algorithm** of [rolling/moving funcitons](https://en.wikipedia.org/wiki/Moving_average), such as a `rolling/moving average`.
+This package implements a staged-programming approach for a highly specialized version of a Savitzky-Golay filter. It is a **generalized, performant algorithm** of [rolling/moving functions](https://en.wikipedia.org/wiki/Moving_average), such as a `rolling/moving average`.
 
-If you would like to read a full blog post on the implementation on it, [you can find some here](miguelraz.github.io/blog).
+If you would like to read a full blog post on the implementation on it, [you can find some here](https://miguelraz.github.io/blog/).
 For a video explanation by Stefan Karpinski, check out the [following video](https://www.youtube.com/watch?v=DRKKAFYM9yo&feature=youtu.be&t=2047)
 
 ### Acknowledgments


### PR DESCRIPTION
Fixed a typo and the link to the blog (relative links do not work since they are relative to the repo). I kept the link to the blog as is, but maybe it should point to [this post](https://miguelraz.github.io/blog/smoothingjiahao/) instead.